### PR TITLE
build(deps): pin Kotlin to 2.3.10 to fix CodeQL autobuild

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,11 @@ updates:
       all-dependencies:
         patterns:
           - "*"
+    ignore:
+      # CodeQL does not support Kotlin >= 2.3.20 yet (KotlinVersionTooRecentError).
+      # Remove this ignore rule once CodeQL releases support for 2.3.20.
+      - dependency-name: "org.jetbrains.kotlin.jvm"
+        versions: [">= 2.3.20"]
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("jvm") version "2.3.20"
+    kotlin("jvm") version "2.3.10" // pinned, see .github/dependabot.yml
     application
 }
 


### PR DESCRIPTION
## Summary

CodeQL's `java-kotlin` analysis was failing on every push to main with `KotlinVersionTooRecentError` after Dependabot bumped the Kotlin JVM plugin to 2.3.20. The `Build` workflow runs on PRs, but CodeQL only runs on pushes to `main`, so the incompatibility wasn't visible until after merge.

Pins Kotlin back to 2.3.10 (the last version CodeQL 2.24.3 supports) and adds a Dependabot ignore rule for `org.jetbrains.kotlin.jvm >= 2.3.20` so the bump doesn't come back automatically. Both the version and the ignore rule have comments pointing to each other; remove both once CodeQL adds support for 2.3.20.