### PR TITLE
fix(deps): correct Dependabot ignore rule dependency name for Kotlin JVM plugin

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
     ignore:
       # CodeQL does not support Kotlin >= 2.3.20 yet (KotlinVersionTooRecentError).
       # Remove this ignore rule once CodeQL releases support for 2.3.20.
-      - dependency-name: "org.jetbrains.kotlin.jvm"
+      - dependency-name: "jvm"
         versions: [">= 2.3.20"]
 
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
The ignore rule added in #22 used `org.jetbrains.kotlin.jvm` as the dependency name, but Dependabot tracks it as `jvm` (visible from PR #23's title). The rule never matched, so Dependabot immediately bumped Kotlin back to 2.3.20.

This fixes the name to `jvm` so the ignore rule actually takes effect.